### PR TITLE
Ensure artifacts url is output correctly

### DIFF
--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
@@ -123,9 +123,9 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
 
         String circleUrl = EnvironmentVariables.envVarOrFromTestingProperty(getProject(), "CIRCLE_BUILD_URL")
                 .map(BetterExec::extractDomain)
-                .orElse("<circle_url>");
+                .orElse("https://<circle_url>");
         return String.format(
-                "See output at: https://%s/output/job/%s/artifacts/%s",
+                "See output at: %s/output/job/%s/artifacts/%s",
                 circleUrl,
                 circleWorkflowJobId.get(),
                 circleNodeIndex.get()

--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure artifacts url is output correctly
+  links:
+  - https://github.com/palantir/better-exec/pull/8


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`CIRCLE_BUILD_URL` already contains the scheme, so you end up having something like:

    https://https://circleci.com/gh/palantir/gradle-jdks/7596

Which is not a valid link and is not clickable.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

Just trimmed the `https://` from the beginning so links are clickable!

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

