### PR TITLE
Allow BetterExec::exec to be overridden

### DIFF
--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
@@ -57,7 +57,7 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
     }
 
     @TaskAction
-    public final void exec() {
+    public void exec() {
         WorkQueue workQueue = getWorkerExecutor().noIsolation();
 
         workQueue.submit(BetterExecAction.class, params -> {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
BetterExec::exec could not be overridden. If you wanted to do a small piece of work on either side of the execution, you couldn't.

## After this PR
BetterExec::exec is no longer final.

## Possible downsides?
Don't think so.
