### PR TITLE
Make `circleci-artifacts` and `environment-variables` implementation dependencies

### DIFF
--- a/better-exec/build.gradle
+++ b/better-exec/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'groovy'
 
 dependencies {
     compileOnly gradleApi()
-    compileOnly 'com.google.errorprone:error_prone_annotations'
+    compileOnlyApi 'com.google.errorprone:error_prone_annotations'
 
     implementation 'com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions'
     implementation 'com.palantir.gradle.utils:platform'

--- a/better-exec/build.gradle
+++ b/better-exec/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'groovy'
 
 dependencies {
     compileOnly gradleApi()
+    compileOnly 'com.google.errorprone:error_prone_annotations'
 
     implementation 'com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions'
     implementation 'com.palantir.gradle.utils:platform'

--- a/better-exec/build.gradle
+++ b/better-exec/build.gradle
@@ -9,10 +9,8 @@ dependencies {
 
     implementation 'com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions'
     implementation 'com.palantir.gradle.utils:platform'
-    // api because when a consumer plugin has a task extending BetterExec, validatePlugins inspects the superclass
-    // and fails to find these types (e.g. ArtifactLocation) if they are not on the compileClasspath
-    api 'com.palantir.gradle.utils:circleci-artifacts'
-    api 'com.palantir.gradle.utils:environment-variables'
+    implementation 'com.palantir.gradle.utils:circleci-artifacts'
+    implementation 'com.palantir.gradle.utils:environment-variables'
 
     testImplementation gradleApi()
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
@@ -15,10 +15,10 @@
  */
 package com.palantir.gradle.betterexec;
 
+import com.google.errorprone.annotations.RestrictedApi;
 import groovy.lang.Closure;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
@@ -29,13 +29,15 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
     private final BetterExecInternals internals;
 
     @Inject
-    protected abstract WorkerExecutor getWorkerExecutor();
-
-    @Inject
-    protected abstract ObjectFactory getObjectFactory();
+    @RestrictedApi(
+            explanation = "Do not use — internal to BetterExec",
+            link = "",
+            allowedOnPath = ".*/com/palantir/gradle/betterexec/.*")
+    protected abstract WorkerExecutor getBetterExecInternalWorkerExecutor();
 
     public BetterExec() {
-        internals = new BetterExecInternals(getObjectFactory(), getProject().getName() + "." + getName());
+        internals =
+                new BetterExecInternals(getProject().getObjects(), getProject().getName() + "." + getName());
 
         getWorkingDir().set(".");
 
@@ -48,7 +50,7 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
 
     @TaskAction
     public final void exec() {
-        WorkQueue workQueue = getWorkerExecutor().noIsolation();
+        WorkQueue workQueue = getBetterExecInternalWorkerExecutor().noIsolation();
 
         workQueue.submit(BetterExecAction.class, params -> {
             params.getCommand().set(getCommand());

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
@@ -15,18 +15,10 @@
  */
 package com.palantir.gradle.betterexec;
 
-import com.palantir.gradle.utils.circleciartifacts.ArtifactLocation;
-import com.palantir.gradle.utils.circleciartifacts.CircleCiArtifacts;
-import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import groovy.lang.Closure;
-import java.util.stream.IntStream;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
@@ -34,31 +26,22 @@ import org.gradle.workers.WorkerExecutor;
 public abstract class BetterExec extends DefaultTask implements BetterExecCommon {
 
     private final SerializableOrSpec<String> retryWhen = SerializableOrSpec.empty();
+    private final BetterExecInternals internals;
 
     @Inject
     protected abstract WorkerExecutor getWorkerExecutor();
 
-    @Nested
-    protected abstract CircleCiArtifacts getCircleCiArtifacts();
-
-    @Nested
-    protected abstract EnvironmentVariables getEnvVarsFromUtils();
-
-    @Internal
-    protected abstract Property<ArtifactLocation> getArtifactLocation();
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
 
     public BetterExec() {
-        getArtifactLocation().set(findAvailableLocation(getProject().getName() + "." + getName()));
-        getArtifactLocation().finalizeValueOnRead();
+        internals = new BetterExecInternals(getObjectFactory(), getProject().getName() + "." + getName());
 
         getWorkingDir().set(".");
 
-        getCircleLogFilePath()
-                .fileProvider(getArtifactLocation()
-                        .map(ArtifactLocation::physicalPath)
-                        .map(RegularFile::getAsFile));
+        getCircleLogFilePath().fileProvider(internals.circleLogFile());
 
-        getShowRealTimeLogs().set(isOnCi().map(isOnCi -> !isOnCi));
+        getShowRealTimeLogs().set(internals.isOnCi().map(isOnCi -> !isOnCi));
         getCheckExitStatus().set(true);
         getMaxRetries().set(getProject().provider(() -> retryWhen.isEmpty() ? 1 : 5));
     }
@@ -80,9 +63,8 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
             params.getShouldIncludeStacktraceForFailure().set(getShouldIncludeStacktraceForFailure());
 
             params.getRetryWhen().set(retryWhen);
-            params.getIsOnCi().set(isOnCi());
-            params.getCircleArtifactsUrlLocation()
-                    .set(getArtifactLocation().map(ArtifactLocation::circleLink).orElse(""));
+            params.getIsOnCi().set(internals.isOnCi());
+            params.getCircleArtifactsUrlLocation().set(internals.circleArtifactsUrl());
         });
     }
 
@@ -106,31 +88,5 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
 
     public final void retryWhenOutputContains(String substring) {
         retryWhen(output -> output.contains(substring));
-    }
-
-    private Provider<Boolean> isOnCi() {
-        return getEnvVarsFromUtils()
-                .envVarOrFromTestingProperty("CI")
-                .map(_value -> true)
-                .orElse(false);
-    }
-
-    private Provider<ArtifactLocation> findAvailableLocation(String baseName) {
-        return getCircleCiArtifacts().resolveArtifactLocation(baseName + ".log").map(location -> {
-            if (!location.physicalPath().getAsFile().exists()) {
-                return location;
-            }
-
-            return IntStream.iterate(2, i -> i + 1)
-                    .mapToObj(i -> {
-                        String fileName = baseName + "." + i + ".log";
-                        return getCircleCiArtifacts()
-                                .resolveArtifactLocation(fileName)
-                                .get();
-                    })
-                    .filter(loc -> !loc.physicalPath().getAsFile().exists())
-                    .findFirst()
-                    .get();
-        });
     }
 }

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExec.java
@@ -31,7 +31,6 @@ public abstract class BetterExec extends DefaultTask implements BetterExecCommon
     @Inject
     @RestrictedApi(
             explanation = "Do not use — internal to BetterExec",
-            link = "",
             allowedOnPath = ".*/com/palantir/gradle/betterexec/.*")
     protected abstract WorkerExecutor getBetterExecInternalWorkerExecutor();
 

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
@@ -1,0 +1,83 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.betterexec;
+
+import com.palantir.gradle.utils.circleciartifacts.ArtifactLocation;
+import com.palantir.gradle.utils.circleciartifacts.CircleCiArtifacts;
+import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
+import java.io.File;
+import java.util.stream.IntStream;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+
+/**
+ * Encapsulates CircleCI artifact and environment variable logic so that {@link BetterExec}'s bytecode does not
+ * directly reference implementation types like {@link ArtifactLocation}, {@link CircleCiArtifacts}, or
+ * {@link EnvironmentVariables}. This allows those dependencies to be {@code implementation} rather than {@code api},
+ * since {@code validatePlugins} can load {@link BetterExec} without needing those types on the compile classpath.
+ */
+final class BetterExecInternals {
+
+    private final CircleCiArtifacts circleCiArtifacts;
+    private final EnvironmentVariables environmentVariables;
+
+    private final Property<ArtifactLocation> artifactLocation;
+
+    BetterExecInternals(ObjectFactory objectFactory, String baseName) {
+        circleCiArtifacts = objectFactory.newInstance(CircleCiArtifacts.class);
+        environmentVariables = objectFactory.newInstance(EnvironmentVariables.class);
+        artifactLocation = objectFactory.property(ArtifactLocation.class);
+
+        artifactLocation.set(findAvailableLocation(baseName));
+        artifactLocation.finalizeValueOnRead();
+    }
+
+    Provider<File> circleLogFile() {
+        return artifactLocation.map(ArtifactLocation::physicalPath).map(RegularFile::getAsFile);
+    }
+
+    Provider<Boolean> isOnCi() {
+        return environmentVariables
+                .envVarOrFromTestingProperty("CI")
+                .map(_value -> true)
+                .orElse(false);
+    }
+
+    Provider<String> circleArtifactsUrl() {
+        return artifactLocation.map(ArtifactLocation::circleLink).orElse("");
+    }
+
+    private Provider<ArtifactLocation> findAvailableLocation(String baseName) {
+        return circleCiArtifacts.resolveArtifactLocation(baseName + ".log").map(location -> {
+            if (!location.physicalPath().getAsFile().exists()) {
+                return location;
+            }
+
+            return IntStream.iterate(2, i -> i + 1)
+                    .mapToObj(i -> {
+                        String fileName = baseName + "." + i + ".log";
+                        return circleCiArtifacts
+                                .resolveArtifactLocation(fileName)
+                                .get();
+                    })
+                    .filter(loc -> !loc.physicalPath().getAsFile().exists())
+                    .findFirst()
+                    .get();
+        });
+    }
+}

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
@@ -30,6 +30,8 @@ import org.gradle.api.provider.Provider;
  * directly reference implementation types like {@link ArtifactLocation}, {@link CircleCiArtifacts}, or
  * {@link EnvironmentVariables}. This allows those dependencies to be {@code implementation} rather than {@code api},
  * since {@code validatePlugins} can load {@link BetterExec} without needing those types on the compile classpath.
+ *
+ * @see <a href="https://github.com/gradle/gradle/issues/37091">gradle/gradle#37091</a>
  */
 final class BetterExecInternals {
 

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
@@ -53,10 +53,7 @@ final class BetterExecInternals {
     }
 
     Provider<Boolean> isOnCi() {
-        return environmentVariables
-                .envVarOrFromTestingProperty("CI")
-                .map(_value -> true)
-                .orElse(false);
+        return environmentVariables.isCi();
     }
 
     Provider<String> circleArtifactsUrl() {

--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
@@ -35,7 +35,6 @@ final class BetterExecInternals {
 
     private final CircleCiArtifacts circleCiArtifacts;
     private final EnvironmentVariables environmentVariables;
-
     private final Property<ArtifactLocation> artifactLocation;
 
     BetterExecInternals(ObjectFactory objectFactory, String baseName) {


### PR DESCRIPTION
## Before this PR

`BetterExec` declares `circleci-artifacts` and `environment-variables` as `api` dependencies because `validatePlugins` inspects the superclass when a consumer plugin extends `BetterExec`, and needs to find types like `ArtifactLocation`, `CircleCiArtifacts`, and `EnvironmentVariables` on the compile classpath. This leaks internal implementation details to consumers.

This is a workaround for [gradle/gradle#37091](https://github.com/gradle/gradle/issues/37091) — `validatePlugins` uses the `compileClasspath` rather than the `runtimeClasspath` to load task classes, so `implementation` dependencies of a superclass are not available during validation.

## After this PR

==COMMIT_MSG==
`circleci-artifacts` and `environment-variables` are `implementation` dependencies instead of `api`.

All CircleCI artifact and environment variable types are moved into a package-private `BetterExecInternals` helper class, so `BetterExec.class` bytecode no longer directly references them. This means the JVM can load `BetterExec` without those types on the compile classpath, and `validatePlugins` succeeds in consumer plugins that extend `BetterExec`.
==COMMIT_MSG==

The previous approach (#138) used `protected abstract` getters which still exposed the types in the class signature. Simply converting those to private fields also didn't work — the types still appeared in `BetterExec`'s bytecode field descriptors and StackMapTable entries, causing `NoClassDefFoundError` during class loading.

## Possible downsides?

None — `BetterExecInternals` is package-private and not part of the public API. The external contract of `BetterExec` is unchanged.