### PR TITLE
Fix configuration cache compatibility in `BetterExecInternals`

### DIFF
--- a/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
+++ b/better-exec/src/main/java/com/palantir/gradle/betterexec/BetterExecInternals.java
@@ -35,16 +35,15 @@ import org.gradle.api.provider.Provider;
  */
 final class BetterExecInternals {
 
-    private final CircleCiArtifacts circleCiArtifacts;
     private final EnvironmentVariables environmentVariables;
     private final Property<ArtifactLocation> artifactLocation;
 
     BetterExecInternals(ObjectFactory objectFactory, String baseName) {
-        circleCiArtifacts = objectFactory.newInstance(CircleCiArtifacts.class);
+        CircleCiArtifacts circleCiArtifacts = objectFactory.newInstance(CircleCiArtifacts.class);
         environmentVariables = objectFactory.newInstance(EnvironmentVariables.class);
         artifactLocation = objectFactory.property(ArtifactLocation.class);
 
-        artifactLocation.set(findAvailableLocation(baseName));
+        artifactLocation.set(findAvailableLocation(circleCiArtifacts, baseName));
         artifactLocation.finalizeValueOnRead();
     }
 
@@ -60,7 +59,8 @@ final class BetterExecInternals {
         return artifactLocation.map(ArtifactLocation::circleLink).orElse("");
     }
 
-    private Provider<ArtifactLocation> findAvailableLocation(String baseName) {
+    private static Provider<ArtifactLocation> findAvailableLocation(
+            CircleCiArtifacts circleCiArtifacts, String baseName) {
         return circleCiArtifacts.resolveArtifactLocation(baseName + ".log").map(location -> {
             if (!location.physicalPath().getAsFile().exists()) {
                 return location;

--- a/better-exec/src/test/java/com/palantir/gradle/betterexec/BetterExecTest.java
+++ b/better-exec/src/test/java/com/palantir/gradle/betterexec/BetterExecTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.files.arbitrary.ArbitraryFile;
-import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.platform.OperatingSystem;
@@ -38,7 +37,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @GradlePluginTests
-@DisabledConfigurationCache
 class BetterExecTest {
 
     @SuppressWarnings("for-rollout:deprecation")
@@ -349,9 +347,10 @@ class BetterExecTest {
                 command = ['true']
             }
 
+            def fooOutputFiles = tasks.foo.outputs.files.files
             task printOutputs {
                 doFirst {
-                    println "foo outputs: ${tasks.foo.outputs.files.files}"
+                    println "foo outputs: ${fooOutputFiles}"
                 }
             }
             """);


### PR DESCRIPTION
## Before this PR

#292 moved `CircleCiArtifacts` and `EnvironmentVariables` into `BetterExecInternals` to make them `implementation` dependencies. However, `circleCiArtifacts` was stored as a field on the class, and Gradle's configuration cache tried to serialise it as part of the task bean graph, failing with:
```
Could not load the value of field transformer of TransformBackedProvider bean
found in field artifactLocation of BetterExecInternals bean ...
▎ Index -1 out of bounds for length 4
```

I think this has such an ugly message as we are catching this during de-serialisation see https://github.com/gradle/gradle/issues/28588 and https://github.com/gradle/gradle/issues/28325

## After this PR

`circleCiArtifacts` is a local variable in the constructor instead of a field, and `findAvailableLocation` is `static`. This prevents Gradle from serializing `CircleCiArtifacts`
 as part of the bean graph while keeping the exact same lazy behavior.

Also fixes two pre-existing test issues exposed by enabling configuration cache:
- A Groovy closure referencing `tasks` at execution time (not config-cache compatible)
- Removal of `@DisabledConfigurationCache` from the test class

## Possible downsides?

## Test plan

- [x] All existing tests pass with configuration cache enabled (`@DisabledConfigurationCache` removed)
- [x] resolves issues in https://github.com/palantir/gradle-conjure/pull/1945when ran locally